### PR TITLE
Update readme for babel 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ const webpackOptions = {
         test: /\.(js|jsx|mjs)$/,
         loader: 'babel-loader',
         options: {
-          presets: ['env', 'react'],
-          plugins: ['transform-class-properties'],
+          presets: ['@babel/preset-env', '@babel/preset-react'],
+          plugins: ['@babel/plugin-proposal-class-properties'],
         },
       }
     ]
@@ -88,8 +88,8 @@ Install dev dependencies
 
 ```shell
 npm i -D @cypress/webpack-preprocessor \
-  babel-loader babel-preset-es2015 babel-preset-react \
-  babel-plugin-transform-class-properties
+  babel-loader @babel/preset-env @babel/preset-react \
+  @babel/plugin-proposal-class-properties
 ```
 
 And write a component using class properties


### PR DESCRIPTION
Do you think it makes sense to update the readme for Babel 7? Babel 7 is now used in the latest Create React App and Parcel.

It'd probably be overkill to include both versions in the readme, so I guess it just depends when you think is the right time to make the switch.

I confirmed these settings work while updating my [React TDD tutorial](https://learntdd.in/react/) to Create React App 2.0 this morning.