### PR TITLE
Need to run transpile script before tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "webpack -d",
     "cy:open": "cypress open",
     "transpile": "tsc",
-    "pretest": "npm run lint",
+    "pretest": "npm run lint && npm run transpile",
     "lint": "standard --verbose --fix *.js src cypress/integration",
     "semantic-release": "semantic-action pre && npm run transpile && npm publish && semantic-action post"
   },


### PR DESCRIPTION
Currently the https://github.com/cypress-io/cypress-test-example-repos fails because the only scripts it runs are `npm install` and `npm run test` - since the ts is not transpiled, this causes the `../../dist` to not be found in the `support/index.js` file.