### PR TITLE
fix: watching for style changes

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -11,7 +11,7 @@ interface ReactModule {
 
 declare namespace Cypress {
   interface Cypress {
-    stylesCache: any
+    stylesCache: Map<string, Array<Node>>
     React: string
     ReactDOM: string
     Styles: string


### PR DESCRIPTION
@bahmutov 
This PR fixes runtime styles not applying correctly if they are added _after_ initial render.

* Added a `MutationObserver` to watch for style changes and apply them to the correct `<head>` and the style cache.

### Todo
[ ] - Figure out a good way to test this.

Up on this fork for available to try out (_will delete after pr close_)
```sh
yarn add -D @zelz/cypress-react-unit-test@2.5.0
```

Could Possibly Fix: https://github.com/bahmutov/cypress-react-unit-test/issues/32#issue-368663025