### PR TITLE
Fix Aliases

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -135,7 +135,7 @@ export const mount = (jsx, alias) => {
         jsx,
         document.getElementById('cypress-jsdom')
       )
-      cy.wrap(component, { log: false }).as(displayname)
+      cy.wrap(component, { log: false }).as(alias || displayname)
     })
   cy.copyComponentStyles(jsx)
     .then(() => {


### PR DESCRIPTION
https://github.com/bahmutov/cypress-react-unit-test/pull/92 broke the alias functionality. If a jsx.type exists, the alias will be ignored. This restores the alias functionality such that a supplied alias will override the jsx.type.