### PR TITLE
Split Cypress test run into 4 containers

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -18,21 +18,8 @@ workflows:
                 name: Linting code 🧹
                 command: npm run lint
 
-      # the test job automatically attaches the workspace
-      # created by the install job, so it is ready to test
-      # - cypress/run:
-      #     name: Test
-      #     requires:
-      #       - Install
-      #     # notice a trick to avoid re-installing dependencies
-      #     # in this job - a do-nothing "install-command" parameter
-      #     install-command: echo 'Nothing to install in this job'
-      #     # we are not going to use results from this job anywhere else
-      #     no-workspace: true
-      #     record: false
-
       - cypress/run:
-          name: Split test
+          name: Test
           parallelism: 4
           requires:
             - Install

--- a/circle.yml
+++ b/circle.yml
@@ -31,6 +31,21 @@ workflows:
           no-workspace: true
           record: false
 
+      - cypress/run:
+          name: Split test
+          parallelism: 4
+          requires:
+            - Install
+          # notice a trick to avoid re-installing dependencies
+          # in this job - a do-nothing "install-command" parameter
+          install-command: echo 'Nothing to install in this job'
+          # we are not going to use results from this job anywhere else
+          no-workspace: true
+          record: false
+          command: |
+            TESTFILES=$(circleci tests glob cypress/integration/**/*spec.* | circleci tests split --total=4)
+            echo "Test files for this machine are $TESTFILES"
+
       # this job attaches the workspace left by the install job
       # so it is ready to run Cypress tests
       # only we will run semantic release script instead

--- a/circle.yml
+++ b/circle.yml
@@ -45,25 +45,24 @@ workflows:
           command: |
             TESTFILES=$(circleci tests glob cypress/integration/**/*spec.* | circleci tests split --total=4)
             echo "Test files for this machine are $TESTFILES"
-
       # this job attaches the workspace left by the install job
       # so it is ready to run Cypress tests
       # only we will run semantic release script instead
-      - cypress/run:
-          name: NPM release
-          # we need newer Node for semantic release
-          executor: cypress/base-12-6-0
-          requires:
-            - Install
-            - Test
-          install-command: echo 'Nothing to install in this job'
-          no-workspace: true
-          # instead of "cypress run" do NPM release 😁
-          # clear environment variables to trick semantic-release
-          # into thinking this is NOT a pull request.
-          # (under the hood the module env-ci is used to check if this is a PR)
-          command: |
-            CIRCLE_PR_NUMBER= \
-            CIRCLE_PULL_REQUEST= \
-            CI_PULL_REQUEST= \
-            npm run semantic-release
+      # - cypress/run:
+      #     name: NPM release
+      #     # we need newer Node for semantic release
+      #     executor: cypress/base-12-6-0
+      #     requires:
+      #       - Install
+      #       - Test
+      #     install-command: echo 'Nothing to install in this job'
+      #     no-workspace: true
+      #     # instead of "cypress run" do NPM release 😁
+      #     # clear environment variables to trick semantic-release
+      #     # into thinking this is NOT a pull request.
+      #     # (under the hood the module env-ci is used to check if this is a PR)
+      #     command: |
+      #       CIRCLE_PR_NUMBER= \
+      #       CIRCLE_PULL_REQUEST= \
+      #       CI_PULL_REQUEST= \
+      #       npm run semantic-release

--- a/circle.yml
+++ b/circle.yml
@@ -33,7 +33,7 @@ workflows:
 
       - cypress/run:
           name: Split test
-          parallelism: 2
+          parallelism: 4
           requires:
             - Install
           # notice a trick to avoid re-installing dependencies
@@ -47,24 +47,26 @@ workflows:
           command: |
             TESTFILES=$(circleci tests glob "cypress/{component,integration}/**/*spec.{js,jsx,ts,tsx}" | circleci tests split --total=2)
             echo "Test files for this machine are $TESTFILES"
+            cypress run --spec $TESTFILES
+
       # this job attaches the workspace left by the install job
       # so it is ready to run Cypress tests
       # only we will run semantic release script instead
-      # - cypress/run:
-      #     name: NPM release
-      #     # we need newer Node for semantic release
-      #     executor: cypress/base-12-6-0
-      #     requires:
-      #       - Install
-      #       - Test
-      #     install-command: echo 'Nothing to install in this job'
-      #     no-workspace: true
-      #     # instead of "cypress run" do NPM release 😁
-      #     # clear environment variables to trick semantic-release
-      #     # into thinking this is NOT a pull request.
-      #     # (under the hood the module env-ci is used to check if this is a PR)
-      #     command: |
-      #       CIRCLE_PR_NUMBER= \
-      #       CIRCLE_PULL_REQUEST= \
-      #       CI_PULL_REQUEST= \
-      #       npm run semantic-release
+      - cypress/run:
+          name: NPM release
+          # we need newer Node for semantic release
+          executor: cypress/base-12-6-0
+          requires:
+            - Install
+            - Test
+          install-command: echo 'Nothing to install in this job'
+          no-workspace: true
+          # instead of "cypress run" do NPM release 😁
+          # clear environment variables to trick semantic-release
+          # into thinking this is NOT a pull request.
+          # (under the hood the module env-ci is used to check if this is a PR)
+          command: |
+            CIRCLE_PR_NUMBER= \
+            CIRCLE_PULL_REQUEST= \
+            CI_PULL_REQUEST= \
+            npm run semantic-release

--- a/circle.yml
+++ b/circle.yml
@@ -34,8 +34,8 @@ workflows:
       - cypress/run:
           name: Split test
           parallelism: 2
-          # requires:
-          #   - Install
+          requires:
+            - Install
           # notice a trick to avoid re-installing dependencies
           # in this job - a do-nothing "install-command" parameter
           install-command: echo 'Nothing to install in this job'

--- a/circle.yml
+++ b/circle.yml
@@ -45,7 +45,7 @@ workflows:
           # following examples from
           # https://circleci.com/docs/2.0/parallelism-faster-jobs/
           command: |
-            TESTFILES=$(circleci tests glob "cypress/integration/**/*spec.{js,jsx,ts,tsx}" | circleci tests split --total=2)
+            TESTFILES=$(circleci tests glob "cypress/{component,integration}/**/*spec.{js,jsx,ts,tsx}" | circleci tests split --total=2)
             echo "Test files for this machine are $TESTFILES"
       # this job attaches the workspace left by the install job
       # so it is ready to run Cypress tests

--- a/circle.yml
+++ b/circle.yml
@@ -32,7 +32,7 @@ workflows:
           # following examples from
           # https://circleci.com/docs/2.0/parallelism-faster-jobs/
           command: |
-            TESTFILES=$(circleci tests glob "cypress/{component,integration}/**/*spec.{js,jsx,ts,tsx}" | circleci tests split --total=2)
+            TESTFILES=$(circleci tests glob "cypress/{component,integration}/**/*spec.{js,jsx,ts,tsx}" | circleci tests split --total=4)
             echo "Test files for this machine are $TESTFILES"
             npx cypress run --spec $TESTFILES
 

--- a/circle.yml
+++ b/circle.yml
@@ -34,7 +34,7 @@ workflows:
           command: |
             TESTFILES=$(circleci tests glob "cypress/{component,integration}/**/*spec.{js,jsx,ts,tsx}" | circleci tests split --total=2)
             echo "Test files for this machine are $TESTFILES"
-            cypress run --spec $TESTFILES
+            npx cypress run --spec $TESTFILES
 
       # this job attaches the workspace left by the install job
       # so it is ready to run Cypress tests

--- a/circle.yml
+++ b/circle.yml
@@ -34,8 +34,8 @@ workflows:
       - cypress/run:
           name: Split test
           parallelism: 2
-          requires:
-            - Install
+          # requires:
+          #   - Install
           # notice a trick to avoid re-installing dependencies
           # in this job - a do-nothing "install-command" parameter
           install-command: echo 'Nothing to install in this job'

--- a/circle.yml
+++ b/circle.yml
@@ -20,20 +20,20 @@ workflows:
 
       # the test job automatically attaches the workspace
       # created by the install job, so it is ready to test
-      - cypress/run:
-          name: Test
-          requires:
-            - Install
-          # notice a trick to avoid re-installing dependencies
-          # in this job - a do-nothing "install-command" parameter
-          install-command: echo 'Nothing to install in this job'
-          # we are not going to use results from this job anywhere else
-          no-workspace: true
-          record: false
+      # - cypress/run:
+      #     name: Test
+      #     requires:
+      #       - Install
+      #     # notice a trick to avoid re-installing dependencies
+      #     # in this job - a do-nothing "install-command" parameter
+      #     install-command: echo 'Nothing to install in this job'
+      #     # we are not going to use results from this job anywhere else
+      #     no-workspace: true
+      #     record: false
 
       - cypress/run:
           name: Split test
-          parallelism: 4
+          parallelism: 2
           requires:
             - Install
           # notice a trick to avoid re-installing dependencies

--- a/circle.yml
+++ b/circle.yml
@@ -42,8 +42,10 @@ workflows:
           # we are not going to use results from this job anywhere else
           no-workspace: true
           record: false
+          # following examples from
+          # https://circleci.com/docs/2.0/parallelism-faster-jobs/
           command: |
-            TESTFILES=$(circleci tests glob cypress/integration/**/*spec.* | circleci tests split --total=4)
+            TESTFILES=$(circleci tests glob "cypress/integration/**/*spec.{js,jsx,ts,tsx}" | circleci tests split --total=2)
             echo "Test files for this machine are $TESTFILES"
       # this job attaches the workspace left by the install job
       # so it is ready to run Cypress tests


### PR DESCRIPTION
```
parallelism: 4
command: |
  TESTFILES=$(circleci tests glob "cypress/{component,integration}/**/*spec.{js,jsx,ts,tsx}" | circleci tests split --total=4)
  echo "Test files for this machine are $TESTFILES"
  npx cypress run --spec $TESTFILES
```