### PR TITLE
feat: give warning when user source makes ReactDOM.render

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Spec | Description
 [use-lodash-fp](cypress/component/basic/use-lodash-fp) | Imports and tests methods from `lodash/fp` dependency
 [document-spec](cypress/component/basic/document) | Checks `document` dimensions from the component
 [styled-components](cypress/component/basic/styled-components) | Test components that use [styled-components](https://www.styled-components.com/)
+[avoid-render](cypress/component/basic/avoid-render) | Shows warning if the user spec accidentally imports source file with `ReactDOM.render` call
 <!-- prettier-ignore-end -->
 
 plus a few smaller sanity specs in [cypress/component/basic](cypress/component/basic) folder.

--- a/cypress/component/basic/avoid-render/index.js
+++ b/cypress/component/basic/avoid-render/index.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+
+const App = () => <div>App is here</div>
+export default App
+
+// typical React application tries to render the component
+// to the default placeholder element
+// if the element does not exist, we get an error
+// "Target container is not a DOM element."
+ReactDOM.render(<App />, document.getElementById('root'))

--- a/cypress/component/basic/avoid-render/spec.js
+++ b/cypress/component/basic/avoid-render/spec.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import { mount } from 'cypress-react-unit-test'
+// importing source file that does ReactDOM.render
+import App from '.'
+
+describe('App', () => {
+  it('loads', () => {
+    mount(<App />)
+    cy.contains('App is here').should('be.visible')
+  })
+})

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -9,7 +9,7 @@ function checkMountModeEnabled() {
   // @ts-ignore
   if (Cypress.spec.specType !== 'component') {
     throw new Error(
-      `In order to use mount or unmount functions please place the spec in component folder`,
+      `[cypress-react-unit-test] 🔥 In order to use mount or unmount functions please place the spec in component folder`,
     )
   }
 }


### PR DESCRIPTION
- closes #158 

Good user experience. If you accidentally import source code with `ReactDOM.render(... 'root')` then show a warning but continue. The component will be rendered into an orphaned element

Before

<img width="812" alt="Screen Shot 2020-05-01 at 4 46 00 PM" src="https://user-images.githubusercontent.com/2212006/80840626-b33d9180-8bcb-11ea-9450-7c190a032b45.png">

After

<img width="841" alt="Screen Shot 2020-05-01 at 4 45 34 PM" src="https://user-images.githubusercontent.com/2212006/80840647-b769af00-8bcb-11ea-822a-96cba3aad3b7.png">
