### PR TITLE
fix: better load webpack config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13905,9 +13905,9 @@
       }
     },
     "find-webpack": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/find-webpack/-/find-webpack-1.10.0.tgz",
-      "integrity": "sha512-5EI/dXzTCsO0TT2jAd86aiXffNoAXEr28hjGRHPea8qnQnUpRl2RPKt3eIEVFu0G6l6lqXc+s2UrNF62LxyCIg==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/find-webpack/-/find-webpack-1.10.1.tgz",
+      "integrity": "sha512-0ze0B7GUw9mC/UPXJUTPwjjGtr2RAT13OKq6uy373oLkVtu3S7UkgzxfI/sxY2Ot1XVl6/tPTzffms0YUTpfxA==",
       "requires": {
         "debug": "4.1.1",
         "find-yarn-workspace-root": "1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13905,9 +13905,9 @@
       }
     },
     "find-webpack": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/find-webpack/-/find-webpack-1.9.2.tgz",
-      "integrity": "sha512-dP/8arVmdcHvB0KwTjLDdifSE/8/kkRbrok6tdBWyTOTlBx+M2otk8lk5CMidOd2wJZH6k5TR5Hc+bsyhhZVRA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/find-webpack/-/find-webpack-1.10.0.tgz",
+      "integrity": "sha512-5EI/dXzTCsO0TT2jAd86aiXffNoAXEr28hjGRHPea8qnQnUpRl2RPKt3eIEVFu0G6l6lqXc+s2UrNF62LxyCIg==",
       "requires": {
         "debug": "4.1.1",
         "find-yarn-workspace-root": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "@cypress/webpack-preprocessor": "5.4.1",
     "babel-plugin-istanbul": "6.0.0",
     "debug": "4.1.1",
-    "find-webpack": "1.10.0",
+    "find-webpack": "1.10.1",
     "mime-types": "2.1.26"
   },
   "release": {

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "@cypress/webpack-preprocessor": "5.4.1",
     "babel-plugin-istanbul": "6.0.0",
     "debug": "4.1.1",
-    "find-webpack": "1.9.2",
+    "find-webpack": "1.10.0",
     "mime-types": "2.1.26"
   },
   "release": {

--- a/plugins/load-webpack/index.js
+++ b/plugins/load-webpack/index.js
@@ -16,14 +16,11 @@ module.exports = (on, config) => {
   }
   debug('got webpack config filename %s', webpackFilename)
   const resolved = path.resolve(webpackFilename)
-  debug('resolved webpack at %s', webpackFilename)
+  debug('resolved webpack at %s', resolved)
 
-  let webpackOptions = require(resolved)
-  debug('loaded webpack options: %o', webpackOptions)
-  if (webpackOptions.default) {
-    // we probably loaded TS file
-    debug('loaded webpack options has .default - taking that as the config')
-    webpackOptions = webpackOptions.default
+  const webpackOptions = findWebpack.tryLoadingWebpackConfig(resolved)
+  if (!webpackOptions) {
+    throw new Error(`Could not load webpack config from ${resolved}`)
   }
 
   debug('webpack options: %o', webpackOptions)


### PR DESCRIPTION
- closes #262 
- closes #256 

Uses a common method from `find-webpack` to load Webpack config and handles react-scripts and functional form