### PR TITLE
feat: Use custom Babel module to enable named imports mocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Folder Name | Description
 [visual-testing-with-percy](examples/visual-testing-with-percy) | [Visual testing](#visual-testing) for components using 3rd party service [Percy.io](https://percy.io/)
 [visual-testing-with-happo](examples/visual-testing-with-happo) | [Visual testing](#visual-testing) for components using 3rd party service [Happo](https://happo.io/)
 [using-babel](examples/using-babel) | Bundling specs and loaded source files using project's existing `.babelrc` file
+[webpack-file](examples/webpack-file) | Load existing `webpack.config.js` file
 [webpack-options](examples/webpack-options) | Using the default Webpack options from `@cypress/webpack-preprocessor` to transpile JSX specs
 <!-- prettier-ignore-end -->
 

--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,9 @@ executors:
     docker:
       - image: 'cypress/base:12.16.2'
 
+environment:
+  DEBUG: find-webpack,cypress-react-unit-test
+
 workflows:
   build:
     jobs:

--- a/circle.yml
+++ b/circle.yml
@@ -6,9 +6,8 @@ executors:
   base-12-16-2:
     docker:
       - image: 'cypress/base:12.16.2'
-
-environment:
-  DEBUG: find-webpack,cypress-react-unit-test
+    environment:
+      DEBUG: find-webpack,cypress-react-unit-test
 
 workflows:
   build:
@@ -122,7 +121,7 @@ workflows:
 
       - cypress/run:
           name: Example Webpack file
-          executor: cypress/base-12
+          executor: base-12-16-2
           requires:
             - Install
           # each example installs "cypress-react-unit-test" as a local dependency (symlink)

--- a/circle.yml
+++ b/circle.yml
@@ -118,6 +118,26 @@ workflows:
                 working_directory: examples/tailwind
 
       - cypress/run:
+          name: Example Webpack file
+          executor: cypress/base-12
+          requires:
+            - Install
+          # each example installs "cypress-react-unit-test" as a local dependency (symlink)
+          install-command: npm install
+          verify-command: echo 'Already verified'
+          no-workspace: true
+          working_directory: examples/webpack-file
+          command: npm test
+          store_artifacts: true
+          post-steps:
+            - run:
+                name: Check coverage 📈
+                command: |
+                  npm run check-coverage
+                  npm run only-covered
+                working_directory: examples/webpack-file
+
+      - cypress/run:
           name: Example Webpack options
           executor: cypress/base-12
           requires:
@@ -271,6 +291,7 @@ workflows:
             - Example Sass
             - Example Snapshots
             - Example Tailwind
+            - Example Webpack file
             - Example Webpack options
             - Visual Sudoku
             - Visual with Percy

--- a/examples/react-scripts-folder/cypress.json
+++ b/examples/react-scripts-folder/cypress.json
@@ -2,7 +2,7 @@
   "fixturesFolder": false,
   "testFiles": "**/*cy-spec.js",
   "viewportWidth": 500,
-  "viewportHeight": 500,
+  "viewportHeight": 800,
   "experimentalComponentTesting": true,
   "componentFolder": "cypress/component"
 }

--- a/examples/react-scripts-folder/cypress/component/App.cy-spec.js
+++ b/examples/react-scripts-folder/cypress/component/App.cy-spec.js
@@ -3,6 +3,8 @@
 import React from 'react'
 import App from '../../src/App'
 import { mount } from 'cypress-react-unit-test'
+import * as calc from '../../src/calc'
+import * as child from '../../src/Child'
 
 describe('App', () => {
   it('renders learn react link', () => {
@@ -14,5 +16,27 @@ describe('App', () => {
   it('renders inline component', () => {
     mount(<div>JSX</div>)
     cy.contains('JSX')
+  })
+
+  it('controls the random number by stubbing named import', () => {
+    // we are stubbing "getRandomNumber" exported by "calc.js"
+    // and imported into "App.js" and called.
+    cy.stub(calc, 'getRandomNumber')
+      .as('lucky')
+      .returns(777)
+    mount(<App />)
+    cy.contains('.random', '777')
+    cy.get('@lucky').should('be.calledOnce')
+  })
+
+  it('stubs an imported child component', () => {
+    cy.stub(child, 'Child')
+      .as('child')
+      .returns(<div className="mock-child">Mock child component</div>)
+    mount(<App />)
+    // App component rendered our mock child component!
+    cy.contains('Mock child component')
+    cy.get('@child').should('have.been.calledTwice')
+    cy.get('.mock-child').should('have.length', 2)
   })
 })

--- a/examples/react-scripts-folder/package.json
+++ b/examples/react-scripts-folder/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "test": "../../node_modules/.bin/cypress run",
     "cy:open": "../../node_modules/.bin/cypress open",
-    "check-coverage": "../../node_modules/.bin/check-coverage src/App.js",
-    "only-covered": "../../node_modules/.bin/only-covered src/App.js"
+    "check-coverage": "../../node_modules/.bin/check-coverage src/App.js src/calc.js",
+    "only-covered": "../../node_modules/.bin/only-covered src/App.js src/calc.js"
   },
   "devDependencies": {
     "cypress-react-unit-test": "file:../.."

--- a/examples/react-scripts-folder/package.json
+++ b/examples/react-scripts-folder/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "test": "../../node_modules/.bin/cypress run",
     "cy:open": "../../node_modules/.bin/cypress open",
-    "check-coverage": "../../node_modules/.bin/check-coverage src/App.js src/calc.js",
-    "only-covered": "../../node_modules/.bin/only-covered src/App.js src/calc.js"
+    "check-coverage": "../../node_modules/.bin/check-coverage src/App.js src/calc.js src/Child.js",
+    "only-covered": "../../node_modules/.bin/only-covered src/App.js src/calc.js src/Child.js"
   },
   "devDependencies": {
     "cypress-react-unit-test": "file:../.."

--- a/examples/react-scripts-folder/src/App.js
+++ b/examples/react-scripts-folder/src/App.js
@@ -3,6 +3,8 @@ import React from 'react'
 import './App.css'
 import logo from './logo.svg' // => "/__root/src/logo.svg"
 import cypressLogo from './cypress-logo-dark.png' // => "/__root/src/cypress-logo-dark.png"
+import { getRandomNumber } from './calc'
+import { Child } from './Child'
 
 // large image will be transformed into
 // a different url static/media/vans.25e5784d.jpg
@@ -22,6 +24,7 @@ function App() {
         <p>
           Edit <code>src/App.js</code> and save to reload.
         </p>
+        <p className="random">This is a random number {getRandomNumber()}</p>
         <a
           className="App-link"
           href="https://reactjs.org"
@@ -31,6 +34,8 @@ function App() {
           Learn React
         </a>
       </header>
+      <Child />
+      <Child />
     </div>
   )
 }

--- a/examples/react-scripts-folder/src/Child.js
+++ b/examples/react-scripts-folder/src/Child.js
@@ -1,0 +1,3 @@
+import React from 'react'
+
+export const Child = () => <div>Real child component</div>

--- a/examples/react-scripts-folder/src/calc.js
+++ b/examples/react-scripts-folder/src/calc.js
@@ -1,0 +1,1 @@
+export const getRandomNumber = () => Math.round(Math.random() * 1000)

--- a/examples/react-scripts/cypress.json
+++ b/examples/react-scripts/cypress.json
@@ -2,7 +2,7 @@
   "fixturesFolder": false,
   "testFiles": "**/*cy-spec.js",
   "viewportWidth": 500,
-  "viewportHeight": 500,
+  "viewportHeight": 800,
   "experimentalComponentTesting": true,
   "componentFolder": "src"
 }

--- a/examples/react-scripts/package.json
+++ b/examples/react-scripts/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "test": "../../node_modules/.bin/cypress run",
     "cy:open": "../../node_modules/.bin/cypress open",
-    "check-coverage": "../../node_modules/.bin/check-coverage src/App.js",
-    "only-covered": "../../node_modules/.bin/only-covered src/App.js"
+    "check-coverage": "../../node_modules/.bin/check-coverage src/App.js src/calc.js",
+    "only-covered": "../../node_modules/.bin/only-covered src/App.js src/calc.js"
   },
   "devDependencies": {
     "cypress-react-unit-test": "file:../.."

--- a/examples/react-scripts/package.json
+++ b/examples/react-scripts/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "test": "../../node_modules/.bin/cypress run",
     "cy:open": "../../node_modules/.bin/cypress open",
-    "check-coverage": "../../node_modules/.bin/check-coverage src/App.js src/calc.js",
-    "only-covered": "../../node_modules/.bin/only-covered src/App.js src/calc.js"
+    "check-coverage": "../../node_modules/.bin/check-coverage src/App.js src/calc.js src/Child.js",
+    "only-covered": "../../node_modules/.bin/only-covered src/App.js src/calc.js src/Child.js"
   },
   "devDependencies": {
     "cypress-react-unit-test": "file:../.."

--- a/examples/react-scripts/src/App.cy-spec.js
+++ b/examples/react-scripts/src/App.cy-spec.js
@@ -4,6 +4,7 @@ import React from 'react'
 import App from './App'
 import { mount } from 'cypress-react-unit-test'
 import * as calc from './calc'
+import * as Child from './Child'
 
 describe('App', () => {
   it('renders learn react link', () => {
@@ -17,5 +18,18 @@ describe('App', () => {
     cy.stub(calc, 'getRandomNumber').returns(777)
     mount(<App />)
     cy.contains('.random', '777')
+
+    // getRandomNumber was also used by the Child component
+    // let's check that it was mocked too
+    cy.contains('.child', 'Real child component, random 777')
+  })
+
+  it('can mock the child component', () => {
+    // Child component we want to stub is the default export
+    cy.stub(Child, 'default')
+      .as('child')
+      .returns(<div className="mock-child">Mock Child component</div>)
+    mount(<App />)
+    cy.contains('.mock-child', 'Mock Child')
   })
 })

--- a/examples/react-scripts/src/App.cy-spec.js
+++ b/examples/react-scripts/src/App.cy-spec.js
@@ -3,10 +3,19 @@
 import React from 'react'
 import App from './App'
 import { mount } from 'cypress-react-unit-test'
+import * as calc from './calc'
 
 describe('App', () => {
   it('renders learn react link', () => {
     mount(<App />)
     cy.contains(/Learn React/)
+  })
+
+  it('controls the random number by stubbing named import', () => {
+    // we are stubbing "getRandomNumber" exported by "calc.js"
+    // and imported into "App.js" and called.
+    cy.stub(calc, 'getRandomNumber').returns(777)
+    mount(<App />)
+    cy.contains('.random', '777')
   })
 })

--- a/examples/react-scripts/src/App.js
+++ b/examples/react-scripts/src/App.js
@@ -3,6 +3,7 @@ import React from 'react'
 import './App.css'
 import logo from './logo.svg' // => "/__root/src/logo.svg"
 import cypressLogo from './cypress-logo-dark.png' // => "/__root/src/cypress-logo-dark.png"
+import { getRandomNumber } from './calc'
 
 // large image will be transformed into
 // a different url static/media/vans.25e5784d.jpg
@@ -22,6 +23,7 @@ function App() {
         <p>
           Edit <code>src/App.js</code> and save to reload.
         </p>
+        <p className="random">This is a random number {getRandomNumber()}</p>
         <a
           className="App-link"
           href="https://reactjs.org"

--- a/examples/react-scripts/src/App.js
+++ b/examples/react-scripts/src/App.js
@@ -4,6 +4,7 @@ import './App.css'
 import logo from './logo.svg' // => "/__root/src/logo.svg"
 import cypressLogo from './cypress-logo-dark.png' // => "/__root/src/cypress-logo-dark.png"
 import { getRandomNumber } from './calc'
+import Child from './Child'
 
 // large image will be transformed into
 // a different url static/media/vans.25e5784d.jpg
@@ -24,6 +25,7 @@ function App() {
           Edit <code>src/App.js</code> and save to reload.
         </p>
         <p className="random">This is a random number {getRandomNumber()}</p>
+        <Child />
         <a
           className="App-link"
           href="https://reactjs.org"

--- a/examples/react-scripts/src/Child.js
+++ b/examples/react-scripts/src/Child.js
@@ -1,0 +1,10 @@
+import React from 'react'
+const calc = require('./calc')
+
+const Child = () => (
+  <div className="child">
+    Real child component, random {calc.getRandomNumber()}
+  </div>
+)
+
+export default Child

--- a/examples/react-scripts/src/calc.js
+++ b/examples/react-scripts/src/calc.js
@@ -1,0 +1,1 @@
+export const getRandomNumber = () => Math.round(Math.random() * 1000)

--- a/examples/using-babel/.babelrc
+++ b/examples/using-babel/.babelrc
@@ -8,9 +8,20 @@
     "@emotion/babel-preset-css-prop"
   ],
   "env": {
+    // TODO switch this to "development" name
     "test": {
       "plugins": [
-        "babel-plugin-istanbul"
+        // during Cypress tests we want to instrument source code
+        // to get code coverage from tests
+        "babel-plugin-istanbul",
+        // we also want to export ES6 modules as objects
+        // to allow mocking named imports
+        [
+          "@babel/plugin-transform-modules-commonjs",
+          {
+            "loose": true
+          }
+        ]
       ]
     }
   }

--- a/examples/using-babel/src/Mock.spec.js
+++ b/examples/using-babel/src/Mock.spec.js
@@ -1,0 +1,16 @@
+/// <reference types="cypress" />
+import React from 'react'
+import { mount } from 'cypress-react-unit-test'
+import Post from './Post'
+import * as calc from './calc'
+
+describe('Mocking', () => {
+  // https://github.com/bahmutov/cypress-react-unit-test/issues/266
+  it.skip('mocks import used by the Post', () => {
+    cy.stub(calc, 'getRandomNumber')
+      .as('lucky')
+      .returns(777)
+    mount(<Post title="post title" children="post text" />)
+    cy.contains('.random', '777')
+  })
+})

--- a/examples/using-babel/src/Post.js
+++ b/examples/using-babel/src/Post.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import Skeleton from 'react-loading-skeleton'
+import { getRandomNumber } from './calc'
 
 export default class Post extends Component {
   static propTypes = {
@@ -30,6 +31,7 @@ export default class Post extends Component {
       <div style={this.getStyle()}>
         <h1>{this.props.title || <Skeleton />}</h1>
         <p>{this.props.children || <Skeleton count={5} />}</p>
+        <p className="random">random id {getRandomNumber()}</p>
       </div>
     )
   }

--- a/examples/using-babel/src/calc.js
+++ b/examples/using-babel/src/calc.js
@@ -1,0 +1,1 @@
+export const getRandomNumber = () => Math.round(Math.random() * 1000)

--- a/examples/webpack-file/.babelrc
+++ b/examples/webpack-file/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-env", "@babel/preset-react"]
+}

--- a/examples/webpack-file/.npmrc
+++ b/examples/webpack-file/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/examples/webpack-file/README.md
+++ b/examples/webpack-file/README.md
@@ -1,6 +1,6 @@
 # example: webpack-file
 
-> Component tests for projects using existing webpack.config.js file
+> Component tests for projects using existing [webpack.config.js](webpack.config.js) file
 
 Note: run `npm install` in this folder to symlink `cypress-react-unit-test` dependency.
 
@@ -9,3 +9,5 @@ npm run cy:open
 # or run headless tests
 npm test
 ```
+
+See tests in the [cypress/component](cypress/component) folder.

--- a/examples/webpack-file/README.md
+++ b/examples/webpack-file/README.md
@@ -1,0 +1,11 @@
+# example: webpack-file
+
+> Component tests for projects using existing webpack.config.js file
+
+Note: run `npm install` in this folder to symlink `cypress-react-unit-test` dependency.
+
+```shell
+npm run cy:open
+# or run headless tests
+npm test
+```

--- a/examples/webpack-file/cypress.json
+++ b/examples/webpack-file/cypress.json
@@ -1,0 +1,7 @@
+{
+  "fixturesFolder": false,
+  "testFiles": "**/*cy-spec.js",
+  "viewportWidth": 500,
+  "viewportHeight": 500,
+  "experimentalComponentTesting": true
+}

--- a/examples/webpack-file/cypress/component/ChildComponent.js
+++ b/examples/webpack-file/cypress/component/ChildComponent.js
@@ -1,0 +1,10 @@
+import React from 'react'
+import { getRandomNumber } from './calc'
+
+const ChildComponent = () => (
+  <div>
+    Child component <p className="random">Random number {getRandomNumber()}</p>
+  </div>
+)
+
+export default ChildComponent

--- a/examples/webpack-file/cypress/component/Mock.cy-spec.js
+++ b/examples/webpack-file/cypress/component/Mock.cy-spec.js
@@ -1,0 +1,24 @@
+/// <reference types="cypress" />
+import React from 'react'
+import { mount } from 'cypress-react-unit-test'
+import ParentComponent from './ParentComponent'
+import * as calc from './calc'
+import * as ChildComponent from './ChildComponent'
+
+describe('Mocking', () => {
+  it('named getRandomNumber imported in the child component', () => {
+    cy.stub(calc, 'getRandomNumber')
+      .as('lucky')
+      .returns(777)
+    mount(<ParentComponent />)
+    cy.contains('.random', '777')
+  })
+
+  it('entire child component exported as default', () => {
+    cy.stub(ChildComponent, 'default')
+      .as('child')
+      .returns(<div className="mock-child">Mock child component</div>)
+    mount(<ParentComponent />)
+    cy.contains('.mock-child', 'Mock child component')
+  })
+})

--- a/examples/webpack-file/cypress/component/ParentComponent.js
+++ b/examples/webpack-file/cypress/component/ParentComponent.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import ChildComponent from './ChildComponent'
+
+const ParentComponent = () => (
+  <div>
+    Parent component, child component below
+    <br />
+    <ChildComponent />
+  </div>
+)
+
+export default ParentComponent

--- a/examples/webpack-file/cypress/component/Test.cy-spec.js
+++ b/examples/webpack-file/cypress/component/Test.cy-spec.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import { mount } from 'cypress-react-unit-test'
+import Test from './Test'
+
+describe('components', () => {
+  it('works', () => {
+    mount(<Test />)
+    cy.contains('Text')
+  })
+
+  it('works with plain div', () => {
+    mount(<div>Text</div>)
+    cy.contains('Text')
+  })
+})

--- a/examples/webpack-file/cypress/component/Test.js
+++ b/examples/webpack-file/cypress/component/Test.js
@@ -1,0 +1,5 @@
+import React from 'react'
+
+const Test = () => <div>Text</div>
+
+export default Test

--- a/examples/webpack-file/cypress/component/calc.js
+++ b/examples/webpack-file/cypress/component/calc.js
@@ -1,0 +1,1 @@
+export const getRandomNumber = () => Math.round(Math.random() * 1000)

--- a/examples/webpack-file/cypress/integration/cy-spec.js
+++ b/examples/webpack-file/cypress/integration/cy-spec.js
@@ -1,0 +1,6 @@
+/// <reference types="cypress" />
+describe('integration spec', () => {
+  it('works', () => {
+    expect(1).to.equal(1)
+  })
+})

--- a/examples/webpack-file/cypress/plugins/index.js
+++ b/examples/webpack-file/cypress/plugins/index.js
@@ -1,0 +1,8 @@
+module.exports = (on, config) => {
+  // from the root of the project (folder with cypress.json file)
+  config.env.webpackFilename = 'webpack.config.js'
+  require('cypress-react-unit-test/plugins/load-webpack')(on, config)
+  // IMPORTANT to return the config object
+  // with the any changed environment variables
+  return config
+}

--- a/examples/webpack-file/cypress/support/index.js
+++ b/examples/webpack-file/cypress/support/index.js
@@ -1,0 +1,3 @@
+require('cypress-react-unit-test/dist/hooks')
+// if we need code coverage, need to include its custom support hook
+require('@cypress/code-coverage/support')

--- a/examples/webpack-file/package.json
+++ b/examples/webpack-file/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "example-webpack-options",
+  "description": "Using default Webpack options to transpile simple tests",
+  "private": true,
+  "scripts": {
+    "test": "../../node_modules/.bin/cypress run",
+    "cy:open": "../../node_modules/.bin/cypress open",
+    "check-coverage": "../../node_modules/.bin/check-coverage Test.js calc.js ParentComponent.js ChildComponent.js",
+    "only-covered": "../../node_modules/.bin/only-covered Test.js calc.js ParentComponent.js ChildComponent.js"
+  },
+  "devDependencies": {
+    "cypress-react-unit-test": "file:../.."
+  }
+}

--- a/examples/webpack-file/webpack.config.js
+++ b/examples/webpack-file/webpack.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.(js|jsx)$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader',
+        },
+      },
+    ],
+  },
+}

--- a/examples/webpack-options/README.md
+++ b/examples/webpack-options/README.md
@@ -2,6 +2,14 @@
 
 The Webpack preprocessor in [cypress/plugins/index.js](cypress/plugins/index.js) adds the Babel React preset to the list of default Webpack plugins. This allows Cypress to transpile JSX code in [cypress/component/Test.cy-spec.js](cypress/component/Test.cy-spec.js) file.
 
+Note: run `npm install` in this folder to symlink `cypress-react-unit-test` dependency.
+
+```shell
+npm run cy:open
+# or run headless tests
+npm test
+```
+
 ```js
 import React from 'react'
 import { mount } from 'cypress-react-unit-test'
@@ -14,3 +22,5 @@ describe('components', () => {
 ```
 
 ![Test screenshot](images/test.png)
+
+More tests are in the [cypress/component](cypress/component) folder.

--- a/examples/webpack-options/cypress/component/ChildComponent.js
+++ b/examples/webpack-options/cypress/component/ChildComponent.js
@@ -1,0 +1,10 @@
+import React from 'react'
+import { getRandomNumber } from './calc'
+
+const ChildComponent = () => (
+  <div>
+    Child component <p className="random">Random number {getRandomNumber()}</p>
+  </div>
+)
+
+export default ChildComponent

--- a/examples/webpack-options/cypress/component/Mock.cy-spec.js
+++ b/examples/webpack-options/cypress/component/Mock.cy-spec.js
@@ -1,0 +1,24 @@
+/// <reference types="cypress" />
+import React from 'react'
+import { mount } from 'cypress-react-unit-test'
+import ParentComponent from './ParentComponent'
+import * as calc from './calc'
+import * as ChildComponent from './ChildComponent'
+
+describe('Mocking', () => {
+  it('named getRandomNumber imported in the child component', () => {
+    cy.stub(calc, 'getRandomNumber')
+      .as('lucky')
+      .returns(777)
+    mount(<ParentComponent />)
+    cy.contains('.random', '777')
+  })
+
+  it('entire child component exported as default', () => {
+    cy.stub(ChildComponent, 'default')
+      .as('child')
+      .returns(<div className="mock-child">Mock child component</div>)
+    mount(<ParentComponent />)
+    cy.contains('.mock-child', 'Mock child component')
+  })
+})

--- a/examples/webpack-options/cypress/component/ParentComponent.js
+++ b/examples/webpack-options/cypress/component/ParentComponent.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import ChildComponent from './ChildComponent'
+
+const ParentComponent = () => (
+  <div>
+    Parent component, child component below
+    <br />
+    <ChildComponent />
+  </div>
+)
+
+export default ParentComponent

--- a/examples/webpack-options/cypress/component/calc.js
+++ b/examples/webpack-options/cypress/component/calc.js
@@ -1,0 +1,1 @@
+export const getRandomNumber = () => Math.round(Math.random() * 1000)

--- a/examples/webpack-options/cypress/plugins/index.js
+++ b/examples/webpack-options/cypress/plugins/index.js
@@ -17,6 +17,15 @@ module.exports = (on, config) => {
     babelLoader.options.plugins = []
   }
   babelLoader.options.plugins.push(require.resolve('babel-plugin-istanbul'))
+
+  // in order to mock named imports, need to include a plugin
+  babelLoader.options.plugins.push([
+    require.resolve('@babel/plugin-transform-modules-commonjs'),
+    {
+      loose: true,
+    },
+  ])
+
   // add code coverage plugin
   require('@cypress/code-coverage/task')(on, config)
 

--- a/examples/webpack-options/package.json
+++ b/examples/webpack-options/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "test": "../../node_modules/.bin/cypress run",
     "cy:open": "../../node_modules/.bin/cypress open",
-    "check-coverage": "../../node_modules/.bin/check-coverage component/Test.js",
-    "only-covered": "../../node_modules/.bin/only-covered component/Test.js"
+    "check-coverage": "../../node_modules/.bin/check-coverage Test.js calc.js ParentComponent.js ChildComponent.js",
+    "only-covered": "../../node_modules/.bin/only-covered Test.js calc.js ParentComponent.js ChildComponent.js"
   },
   "devDependencies": {
     "cypress-react-unit-test": "file:../.."

--- a/package-lock.json
+++ b/package-lock.json
@@ -13915,9 +13915,9 @@
       }
     },
     "find-webpack": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/find-webpack/-/find-webpack-1.10.1.tgz",
-      "integrity": "sha512-0ze0B7GUw9mC/UPXJUTPwjjGtr2RAT13OKq6uy373oLkVtu3S7UkgzxfI/sxY2Ot1XVl6/tPTzffms0YUTpfxA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/find-webpack/-/find-webpack-1.11.1.tgz",
+      "integrity": "sha512-EE6FIxnx4lJpL5nj2Lem40WULKvWavy36w21jcMPWyNUtVclqACp98H11xsRqlGnwl1J56CO1QG97dUkd6biEw==",
       "requires": {
         "debug": "4.1.1",
         "find-yarn-workspace-root": "1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13915,9 +13915,9 @@
       }
     },
     "find-webpack": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/find-webpack/-/find-webpack-1.11.1.tgz",
-      "integrity": "sha512-EE6FIxnx4lJpL5nj2Lem40WULKvWavy36w21jcMPWyNUtVclqACp98H11xsRqlGnwl1J56CO1QG97dUkd6biEw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/find-webpack/-/find-webpack-1.12.0.tgz",
+      "integrity": "sha512-MCOVlKEavNaM3H+prwar17E3I2z/3FtJgXNZc7ldihYtEMDU4kb5c5Cj+VsK1lvhHG2dkCgDNqxIfwv0qnCVQA==",
       "requires": {
         "debug": "4.1.1",
         "find-yarn-workspace-root": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "@babel/core": "7.4.5",
     "@babel/plugin-proposal-class-properties": "7.4.4",
     "@babel/plugin-syntax-dynamic-import": "7.8.3",
-    "@babel/plugin-transform-modules-commonjs": "7.7.5",
     "@babel/preset-env": "7.4.5",
     "@babel/preset-react": "7.0.0",
     "@babel/preset-typescript": "7.10.1",
@@ -122,11 +121,12 @@
     "url": "https://github.com/bahmutov/cypress-react-unit-test.git"
   },
   "dependencies": {
+    "@babel/plugin-transform-modules-commonjs": "7.7.5",
     "@cypress/code-coverage": "3.8.0",
     "@cypress/webpack-preprocessor": "5.4.1",
     "babel-plugin-istanbul": "6.0.0",
     "debug": "4.1.1",
-    "find-webpack": "1.10.1",
+    "find-webpack": "1.11.1",
     "mime-types": "2.1.26"
   },
   "release": {

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "@cypress/webpack-preprocessor": "5.4.1",
     "babel-plugin-istanbul": "6.0.0",
     "debug": "4.1.1",
-    "find-webpack": "1.11.1",
+    "find-webpack": "1.12.0",
     "mime-types": "2.1.26"
   },
   "release": {

--- a/plugins/babelrc/file-preprocessor.js
+++ b/plugins/babelrc/file-preprocessor.js
@@ -3,6 +3,7 @@
 const debug = require('debug')('cypress-react-unit-test')
 const webpackPreprocessor = require('@cypress/webpack-preprocessor')
 const { addImageRedirect } = require('../utils/add-image-redirect')
+const babelCore = require('@babel/core')
 
 // note: modifies the input object
 function enableBabelrc(webpackOptions) {
@@ -34,10 +35,23 @@ function enableBabelrc(webpackOptions) {
   // we allow Babel loader to load the presets and plugins
   // from the project's .babelrc file
   delete babelLoaderOptions.presets
+  delete babelLoaderOptions.plugins
+
+  debug('babel loader options %o', babelLoaderOptions)
 }
 
 module.exports = config => {
   debug('env object %o', config.env)
+
+  const nodeEnvironment = 'development'
+  if (!process.env.BABEL_ENV) {
+    debug('setting BABEL_ENV to %s', nodeEnvironment)
+    process.env.BABEL_ENV = nodeEnvironment
+  }
+  if (!process.env.NODE_ENV) {
+    debug('setting NODE_ENV to %s', nodeEnvironment)
+    process.env.NODE_ENV = nodeEnvironment
+  }
 
   const coverageIsDisabled =
     config && config.env && config.env.coverage === false

--- a/plugins/cra-v3/file-preprocessor.js
+++ b/plugins/cra-v3/file-preprocessor.js
@@ -38,6 +38,8 @@ module.exports = config => {
     reactScripts: true,
     addFolderToTranspile: config.componentFolder,
     coverage: !coverageIsDisabled,
+    // insert Babel plugin to mock named imports
+    looseModules: true,
   }
   const preprocessorOptions = getWebpackPreprocessorOptions(opts)
 

--- a/plugins/load-webpack/index.js
+++ b/plugins/load-webpack/index.js
@@ -32,6 +32,8 @@ module.exports = (on, config) => {
   const opts = {
     reactScripts: true,
     coverage: !coverageIsDisabled,
+    // insert Babel plugin to mock named imports
+    looseModules: true,
   }
 
   findWebpack.cleanForCypress(opts, webpackOptions)


### PR DESCRIPTION
- closes #233
- closes #268 
- [x] works with react-scripts
- [x] works with Webpack config if we can find Babel https://github.com/bahmutov/cypress-react-unit-test/issues/268
- ~works with Babelrc~ https://github.com/bahmutov/cypress-react-unit-test/issues/266