### PR TITLE
write a wrapper to verify number of expected tests

### DIFF
--- a/examples/react-scripts-folder/package.json
+++ b/examples/react-scripts-folder/package.json
@@ -3,7 +3,7 @@
   "description": "Handles component tests from cypress folder",
   "private": true,
   "scripts": {
-    "test": "../../node_modules/.bin/cypress run",
+    "test": "node ../../scripts/cypress-expect run --passing 5",
     "cy:open": "../../node_modules/.bin/cypress open",
     "check-coverage": "../../node_modules/.bin/check-coverage src/App.js src/calc.js src/Child.js",
     "only-covered": "../../node_modules/.bin/only-covered src/App.js src/calc.js src/Child.js"

--- a/examples/react-scripts/package.json
+++ b/examples/react-scripts/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "../../node_modules/.bin/react-scripts start",
-    "test": "../../node_modules/.bin/cypress run",
+    "test": "node ../../scripts/cypress-expect run --passing 10",
     "cy:open": "../../node_modules/.bin/cypress open",
     "check-coverage": "../../node_modules/.bin/check-coverage src/App.js src/calc.js src/Child.js cypress/fixtures/add.js",
     "only-covered": "../../node_modules/.bin/only-covered src/App.js src/calc.js src/Child.js cypress/fixtures/add.js"

--- a/examples/using-babel/package.json
+++ b/examples/using-babel/package.json
@@ -3,7 +3,7 @@
   "description": "Component testing for projects using Babel config",
   "private": true,
   "scripts": {
-    "test": "../../node_modules/.bin/cypress run",
+    "test": "node ../../scripts/cypress-expect run --passing 17",
     "cy:open": "../../node_modules/.bin/cypress open"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@types/node": "9.6.49",
     "@types/react": "16.9.16",
     "@types/react-dom": "16.9.4",
+    "arg": "4.1.3",
     "autoprefixer": "9.7.6",
     "axios": "0.18.1",
     "babel-loader": "8.0.6",

--- a/scripts/cypress-expect.js
+++ b/scripts/cypress-expect.js
@@ -1,0 +1,61 @@
+// runs Cypress with "normal" CLI parameters
+// but after the run verifies the expected number of passing tests
+const cypress = require('cypress')
+const debug = require('debug')('cypress-expect')
+const arg = require('arg')
+
+const args = arg({
+  '--passing': Number, // number of total passing tests to expect
+})
+if (typeof args['--passing'] !== 'number') {
+  console.error('expected a number of --passing tests', args['--passing'])
+  process.exit(1)
+}
+if (typeof args['--passing'] < 0) {
+  console.error('expected a number of --passing tests', args['--passing'])
+  process.exit(1)
+}
+
+const parseArguments = async () => {
+  // remove all our arguments to let Cypress only deal with its arguments
+  const cliArgs = args._
+  if (cliArgs[0] !== 'cypress') {
+    cliArgs.unshift('cypress')
+  }
+
+  debug('parsing Cypress CLI %o', cliArgs)
+  return await cypress.cli.parseRunArguments(cliArgs)
+}
+
+parseArguments()
+  .then(options => {
+    debug('parsed CLI options %o', options)
+
+    return cypress.run(options)
+  })
+  .then(runResults => {
+    // see https://on.cypress.io/module-api
+    if (runResults.failures) {
+      console.error(runResults.message)
+      process.exit(1)
+    }
+
+    if (runResults.totalFailed) {
+      console.error('%d test(s) failed', runResults.totalFailed)
+      process.exit(runResults.totalFailed)
+    }
+
+    // make sure the expected number of tests executed
+    if (runResults.totalPassed !== args['--passing']) {
+      console.error(
+        'expected %d passing tests, got %d',
+        args['--passing'],
+        runResults.totalPassed,
+      )
+      process.exit(1)
+    }
+  })
+  .catch(e => {
+    console.error(e)
+    process.exit(1)
+  })


### PR DESCRIPTION
- closes #356

`node scripts/cypress-expect --passing <N>`

Using just a few projects for now, should be enough to catch mismatch or configuration change