### PR TITLE
testing how Percy handles test retries

### DIFF
--- a/examples/visual-testing-with-percy/README.md
+++ b/examples/visual-testing-with-percy/README.md
@@ -56,3 +56,7 @@ If a pull request introduces visual changes, they are caught and shown as a diff
 ![Visual change](images/diff.gif)
 
 **Tip:** you can use any [visual testing](https://on.cypress.io/visual-testing) plugin with component testing.
+
+### Test retries
+
+Testing how Percy handles Cypress test retries.

--- a/examples/visual-testing-with-percy/src/test-retries.cy-spec.js
+++ b/examples/visual-testing-with-percy/src/test-retries.cy-spec.js
@@ -1,0 +1,38 @@
+import React from 'react'
+import { mount } from 'cypress-react-unit-test'
+
+// test retries from
+// https://github.com/cypress-io/cypress/pull/3968
+// you can skip the tests if there is no retries feature
+const describeOrSkip = Cypress.getTestRetries ? describe : describe.skip
+describeOrSkip('Test', () => {
+  const Hello = () => {
+    // this is how you can get the current retry number
+    // attempt 1: (first test execution) retry = 0
+    // attempt 2: (second test execution) retry = 1
+    // attempt 3: retry = 2,
+    // etc
+    const n = cy.state('test').currentRetry
+      ? cy.state('test').currentRetry()
+      : 0
+    return <div>retry {n}</div>
+  }
+
+  it.skip('does not retry', { retries: 0 }, () => {
+    mount(<Hello />)
+    cy.contains('retry 0')
+
+    // now let's fail the test - it won't retry it
+    // enable manually to observe
+    // cy.contains('retry 1')
+  })
+
+  it('retries', { retries: 3 }, () => {
+    mount(<Hello />)
+    cy.contains('retry') // ensure the component has rendered
+
+    // now let's fail the test - it will retry several times and pass
+    cy.percySnapshot('Test retry')
+    cy.contains('retry 3', { timeout: 1500 })
+  })
+})


### PR DESCRIPTION
```js
it('retries', { retries: 3 }, () => {
  mount(<Hello />)
  cy.contains('retry') // ensure the component has rendered

  // now let's fail the test - it will retry several times and pass
  cy.percySnapshot('Test retry')
  cy.contains('retry 3', { timeout: 1500 })
})
```

Right now it fails with

```
[percy] snapshot taken: 'Test retry'
[percy] snapshot taken: 'Test retry'
[percy] StatusCodeError 400 - {"errors":[{"status":"bad_request"},
{"source":{"pointer":"/data/attributes/base"},
"detail":"The name of each snapshot must be unique, and this name already exists in the build: 
'Test retry' -- You can fix this by passing a 'name' param when creating the snapshot. 
See the docs for more info on identifying snapshots for your specific client: 
https://percy.io/docs"}]} 
| Fri Jul 31 2020 13:44:31 GMT-0400 (Eastern Daylight Time)
```

Suggestion: Percy Cypress plugin can take the test retry into account and ONLY consider the last test