### PR TITLE
add example with snapshots and test retries

### DIFF
--- a/examples/snapshots/cypress/component/PositiveCounter-spec.js
+++ b/examples/snapshots/cypress/component/PositiveCounter-spec.js
@@ -79,3 +79,23 @@ describe('PositiveCounter', () => {
       .toMatchSnapshot()
   })
 })
+
+// test retries from
+// https://github.com/cypress-io/cypress/pull/3968
+// you can skip the tests if there is no retries feature
+const describeOrSkip = Cypress.getTestRetries ? describe : describe.skip
+describeOrSkip('Retries', () => {
+  it.skip('work with snapshots', { retries: 2 }, () => {
+    mount(<PositiveCounter />)
+    cy.contains('Value: 0')
+
+    // click the button the current number of retries
+    const n = cy.state('test').currentRetry()
+    Cypress._.times(n, () => {
+      cy.get('.increment').click()
+    })
+
+    // make sure the component updates until it reaches counter 2
+    cy.contains('Value:').toMatchHTML()
+  })
+})

--- a/examples/snapshots/cypress/component/__snapshots__/PositiveCounter-spec.js.snap
+++ b/examples/snapshots/cypress/component/__snapshots__/PositiveCounter-spec.js.snap
@@ -22,3 +22,13 @@ exports[`PositiveCounter > starts with zero #0`] =
 {
   "html": "<span>Value: 0<button class=\"decrement\">−</button><button class=\"increment\">+</button></span>"
 };
+
+exports[`Retries > work with snapshots #0`] =
+{
+  "html": "<span>Value: 2<button class=\"decrement\">−</button><button class=\"increment\">+</button></span>"
+};
+
+exports[`Retries > work with snapshots #1`] =
+{
+  "html": "<span>Value: 1<button class=\"decrement\">−</button><button class=\"increment\">+</button></span>"
+};


### PR DESCRIPTION
Seems plugin https://github.com/meinaart/cypress-plugin-snapshots thinks every retry is just another snapshot in the same test, thus it fails. 

```js
const describeOrSkip = Cypress.getTestRetries ? describe : describe.skip
describeOrSkip('Retries', () => {
  it('work with snapshots', { retries: 2 }, () => {
    mount(<PositiveCounter />)
    cy.contains('Value: 0')

    // click the button the current number of retries
    const n = cy.state('test').currentRetry()
    Cypress._.times(n, () => {
      cy.get('.increment').click()
    })

    // make sure the component updates until it reaches counter 2
    cy.contains('Value:').toMatchHTML()
  })
})
```

where the snapshot was saved previously should be
```js
exports[`Retries > work with snapshots #0`] =
{
  "html": "<span>Value: 2<button class=\"decrement\">−</button><button class=\"increment\">+</button></span>"
};
```

instead it retries (because the snapshot does not match) and then _saves new snapshot_

```js
exports[`Retries > work with snapshots #1`] =
{
  "html": "<span>Value: 1<button class=\"decrement\">−</button><button class=\"increment\">+</button></span>"
};
```