### PR TITLE
chore: react-selector tests fixed

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -8,12 +8,12 @@
     "cypress-react-unit-test": {
       "react": "node_modules/react/umd/react.development.js",
       "react-dom": "node_modules/react-dom/umd/react-dom.development.js"
+    },
+    "cypress-react-selector": {
+      "root": "#cypress-root"
     }
   },
-  "ignoreTestFiles": [
-    "**/__snapshots__/*",
-    "**/__image_snapshots__/*"
-  ],
+  "ignoreTestFiles": ["**/__snapshots__/*", "**/__image_snapshots__/*"],
   "experimentalComponentTesting": true,
   "experimentalFetchPolyfill": true
 }

--- a/cypress/component/advanced/react-book-example/src/components/ProductsList.spec.js
+++ b/cypress/component/advanced/react-book-example/src/components/ProductsList.spec.js
@@ -1,5 +1,4 @@
 /// <reference types="cypress" />
-import 'cypress-react-selector'
 import { mount } from 'cypress-react-unit-test'
 import React from 'react'
 import ProductsList from './ProductsList.jsx'
@@ -21,9 +20,8 @@ describe('Selecting by React props and state', () => {
         })
       mount(<ProductsList />)
 
-      // use https://github.com/abhinaba-ghosh/cypress-react-selector
       // to find DOM elements by React component constructor name, props, or state
-      cy.waitForReact(1000, '#cypress-root')
+      cy.waitForReact()
     })
 
     it('renders products', () => {
@@ -36,15 +34,15 @@ describe('Selecting by React props and state', () => {
       cy.log('**cy.react**')
       // find the top level <ProductsContainer> that we have mounted
       // under imported name "ProductsList"
-      cy.react('ProductsContainer').should('have.class', 'product-container')
-      // for more ways to find components, see
-      // https://github.com/abhinaba-ghosh/cypress-react-selector#how-to-use-react-selector
+      cy.react('ProductsContainer')
+        .first()
+        .should('have.class', 'product-container')
       // find all instances of <AProduct> component
       cy.react('AProduct').should('have.length', 2)
       // find a single instance with prop
       // <AProduct name={'Second item'} />
-      cy.react('AProduct', { name: 'Second item' })
-        .should('be.visible')
+      cy.react('AProduct', { props: { name: 'Second item' } })
+        .first()
         .find('.name')
         .and('have.text', 'Second item')
     })
@@ -52,40 +50,38 @@ describe('Selecting by React props and state', () => {
     it('find React components', () => {
       cy.log('**cy.getReact**')
       // returns React component wrapper with props
-      cy.getReact('AProduct', { name: 'Second item' })
+      cy.getReact('AProduct', { props: { name: 'Second item' } })
         .getProps()
         .should('deep.equal', { name: 'Second item' })
-      cy.getReact('AProduct', { name: 'First item' })
+      cy.getReact('AProduct', { props: { name: 'First item' } })
         // get single prop
         .getProps('name')
         .should('eq', 'First item')
       cy.log('**.getCurrentState**')
-      cy.getReact('AProduct', { name: 'Second item' })
+      cy.getReact('AProduct', { props: { name: 'Second item' } })
         .getCurrentState()
         .should('include', { myName: 'Second item' })
 
       // find component using state
-      cy.getReact('AProduct', null, { myName: 'Second item' }).should('exist')
+      cy.getReact('AProduct', { state: { myName: 'Second item' } }).should(
+        'exist',
+      )
     })
 
-    // SKIP: https://github.com/bahmutov/cypress-react-unit-test/issues/378
-    it.skip('chains getReact', () => {
+    it('chains getReact', () => {
       // note that by itself, the component is found
-      cy.getReact('AProduct', { name: 'First item' })
+      cy.getReact('AProduct', { props: { name: 'First item' } })
         .getProps('name')
         .should('eq', 'First item')
 
       // chaining getReact
       cy.getReact('ProductsContainer')
-        .should('not.be.empty')
-        // the second .getReact returns nothing
-        .getReact('AProduct', { name: 'First item' })
+        .getReact('AProduct', { props: { name: 'First item' } })
         .getProps('name')
         .should('eq', 'First item')
     })
 
-    // SKIP: https://github.com/bahmutov/cypress-react-unit-test/issues/381
-    it.skip('finds components by props and state', () => {
+    it('finds components by props and state', () => {
       // by clicking on the Order button we change the
       // internal state of that component
       cy.contains('.product', 'First item')
@@ -99,15 +95,12 @@ describe('Selecting by React props and state', () => {
         .should('have.text', 'First item')
 
       // now find that component using the state value
-      // DOES NOT WORK FOR SOME REASON
-      cy.react('AProduct', null, { orderCount: 1 })
-        .should('not.be.empty')
+      cy.react('AProduct', { state: { orderCount: 1 } })
         .find('.name')
         .should('have.text', 'First item')
     })
 
-    // SKIP: https://github.com/bahmutov/cypress-react-unit-test/issues/381
-    it.skip('finds components by props and state (click twice)', () => {
+    it('finds components by props and state (click twice)', () => {
       // by clicking on the Order button we change the
       // internal state of that component
       cy.contains('.product', 'First item')
@@ -116,15 +109,14 @@ describe('Selecting by React props and state', () => {
         .click()
 
       // now find that component using the state value
-      cy.react('AProduct', null, { orderCount: 2 })
+      cy.react('AProduct', { state: { orderCount: 2 } })
         .find('.name')
         .should('have.text', 'First item')
     })
   })
 
   context('with delay', () => {
-    // SKIP https://github.com/bahmutov/cypress-react-unit-test/issues/379
-    it.skip('retries until component is found', () => {
+    it('retries until component is found', () => {
       // or the command times out
       const products = [
         { id: 1, name: 'First item' },
@@ -142,13 +134,14 @@ describe('Selecting by React props and state', () => {
         .resolves(Cypress.Promise.resolve(response).delay(1000))
       mount(<ProductsList />)
 
-      // use https://github.com/abhinaba-ghosh/cypress-react-selector
       // to find DOM elements by React component constructor name, props, or state
-      cy.waitForReact(1000, '#cypress-root')
+      cy.waitForReact()
       // cy.react should requery the elements until
       // the assertions that follow it are satisfied,
       // or, if there are no assertions, that an element is found
-      cy.react('AProduct').should('have.length', 2)
+      cy.react('AProduct', {
+        props: { name: 'Second item' },
+      }).should('have.length', '1')
     })
   })
 })

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -16,3 +16,4 @@
 // custom commands provided by this package, built from TypeScript code in "lib"
 // using "npm run transpile"
 import 'cypress-react-unit-test/hooks'
+import 'cypress-react-selector'

--- a/package-lock.json
+++ b/package-lock.json
@@ -11561,12 +11561,12 @@
       }
     },
     "cypress-react-selector": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cypress-react-selector/-/cypress-react-selector-1.1.1.tgz",
-      "integrity": "sha512-BJuQi+itEeL1+EHrKhGfBQepo9ZhOF5Bj+VDFZH27UBjLkcEYx/fPknkNIO88NnTtg6SrLr7Z10OuVEE3x1CaA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cypress-react-selector/-/cypress-react-selector-2.0.1.tgz",
+      "integrity": "sha512-McEEN9cjFTYCKn6KVYZsDx51IJjc7X32xhGdiaU4YlN2mna/su5P2vUTHZaouTlDWjnMvPOzndENssQlhU4GWQ==",
       "dev": true,
       "requires": {
-        "resq": "^1.7.1"
+        "resq": "1.8.0"
       }
     },
     "d": {
@@ -14909,8 +14909,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": false,
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "optional": true
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "aproba": {
           "version": "1.2.0",
@@ -14931,14 +14930,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "resolved": false,
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "optional": true
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -14953,20 +14950,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "resolved": false,
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "optional": true
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "optional": true
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "optional": true
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -15083,8 +15077,7 @@
         "inherits": {
           "version": "2.0.4",
           "resolved": false,
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-          "optional": true
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "ini": {
           "version": "1.3.5",
@@ -15096,7 +15089,6 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -15111,7 +15103,6 @@
           "version": "3.0.4",
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -15119,14 +15110,12 @@
         "minimist": {
           "version": "1.2.5",
           "resolved": false,
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "optional": true
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
         "minipass": {
           "version": "2.9.0",
           "resolved": false,
           "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -15145,7 +15134,6 @@
           "version": "0.5.3",
           "resolved": false,
           "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
-          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -15207,8 +15195,7 @@
         "npm-normalize-package-bin": {
           "version": "1.0.1",
           "resolved": false,
-          "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
-          "optional": true
+          "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
         },
         "npm-packlist": {
           "version": "1.4.8",
@@ -15236,8 +15223,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "resolved": false,
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "optional": true
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "object-assign": {
           "version": "4.1.1",
@@ -15249,7 +15235,6 @@
           "version": "1.4.0",
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -15327,8 +15312,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": false,
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "optional": true
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -15364,7 +15348,6 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -15384,7 +15367,6 @@
           "version": "3.0.1",
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -15428,14 +15410,12 @@
         "wrappy": {
           "version": "1.0.2",
           "resolved": false,
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "optional": true
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "yallist": {
           "version": "3.1.1",
           "resolved": false,
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-          "optional": true
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
         }
       }
     },
@@ -31933,9 +31913,9 @@
       }
     },
     "resq": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/resq/-/resq-1.7.1.tgz",
-      "integrity": "sha512-09u9Q5SAuJfAW5UoVAmvRtLvCOMaKP+djiixTXsZvPaojGKhuvc0Nfvp84U1rIfopJWEOXi5ywpCFwCk7mj8Xw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/resq/-/resq-1.8.0.tgz",
+      "integrity": "sha512-VObcnfPcE6/EKfHqsi5qoJ0+BF9qfl5181CytP1su3HgzilqF03DrQ+Y7kZQrd+5myfmantl9W3/5uUcpwvKeg==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "cypress-axe": "0.8.1",
     "cypress-image-snapshot": "3.1.1",
     "cypress-plugin-snapshots": "1.4.4",
-    "cypress-react-selector": "1.1.1",
+    "cypress-react-selector": "2.0.1",
     "date-fns": "2.13.0",
     "happo-cypress": "1.7.3",
     "happo.io": "5.6.1",


### PR DESCRIPTION
- Breaking changes introduced. Now user needs to send the props and states as `reactOpts` object
- root configuration can be done through `env`

![Screenshot 2020-08-16 at 3 58 04 AM](https://user-images.githubusercontent.com/23141842/90322847-f2270580-df76-11ea-94c3-878c3b354801.png)
