### PR TITLE
add example with path aliases to advanced examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Spec | Description
 [mocking-axios](cypress/component/advanced/mocking-axios) | Stubbing methods from a 3rd party component like `axios`
 [mocking-component](cypress/component/advanced/mocking-component) | Replaced a child component with dummy component during test
 [mocking-imports](cypress/component/advanced/mocking-imports) | Stub a named ES6 import in various situations
+[path-aliases](cypress/component/advanced/path-aliases) | Specs import components using path aliases defined in the Webpack config
 [react-router-v6](cypress/component/advanced/react-router-v6) | Example testing a [React Router v6](https://github.com/ReactTraining/react-router). Both browser and in memory routers
 [renderless](cypress/component/advanced/renderless) | Testing a component that does not need to render itself into the DOM
 [set-timeout-example](cypress/component/advanced/set-timeout-example) | Control the clock with `cy.tick` and test loading components that use `setTimeout`

--- a/cypress/component/advanced/path-aliases/Hello.js
+++ b/cypress/component/advanced/path-aliases/Hello.js
@@ -1,0 +1,5 @@
+import React from 'react'
+
+const Hello = () => <div>Hello!</div>
+
+export default Hello

--- a/cypress/component/advanced/path-aliases/README.md
+++ b/cypress/component/advanced/path-aliases/README.md
@@ -1,0 +1,22 @@
+# path-aliases
+
+Specs can import components (and other files) using path aliases defined in the Webpack config file. For example [spec.js](spec.js) uses the following alias to load the component
+
+```js
+import Hello from '@advanced/path-aliases/Hello'
+```
+
+And the Webpack config file in `cypress/plugins` defines this alias
+
+```js
+const webpackOptions = {
+  resolve: {
+    extensions: ['.js', '.ts', '.jsx', '.tsx'],
+    alias: {
+      // exercise path aliases in the specs
+      // https://glebbahmutov.com/blog/using-ts-aliases-in-cypress-tests/
+      '@advanced': path.resolve(__dirname, '..', 'component', 'advanced'),
+    },
+  },
+}
+```

--- a/cypress/component/advanced/path-aliases/spec.js
+++ b/cypress/component/advanced/path-aliases/spec.js
@@ -1,0 +1,14 @@
+/// <reference types="cypress" />
+import React from 'react'
+import { mount } from 'cypress-react-unit-test'
+
+// use path alias defined in webpack config used by Cypress
+// in reality should resolve to "./Hello.js"
+import Hello from '@advanced/path-aliases/Hello'
+
+describe('import path alias', () => {
+  it('Hello works', () => {
+    mount(<Hello />)
+    cy.contains('Hello!').should('be.visible')
+  })
+})

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -2,12 +2,21 @@ const path = require('path')
 const webpackPreprocessor = require('@cypress/webpack-preprocessor')
 const babelConfig = require('../../babel.config.js')
 
-/** @type import("webpack").Configuration */
+/**
+ * Webpack options used by Cypress to transpile specs and components.
+ * Could be built on top of the app's webpack config if needed
+ *
+ * @type import("webpack").Configuration
+ */
 const webpackOptions = {
   resolve: {
     extensions: ['.js', '.ts', '.jsx', '.tsx'],
     alias: {
       react: path.resolve('./node_modules/react'),
+      // exercise path aliases in the specs
+      // https://glebbahmutov.com/blog/using-ts-aliases-in-cypress-tests/
+      '@advanced': path.resolve(__dirname, '..', 'component', 'advanced'),
+      '@basic': path.resolve(__dirname, '..', 'component', 'basic'),
     },
   },
   mode: 'development',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,6 @@
+// WARNING: this is a typical webpack config for application code
+// to see the webpack config used by Cypress to transpile specs and components
+// open cypress/plugins/index.js file
 const path = require('path')
 const babelConfig = require('./babel.config')
 


### PR DESCRIPTION
add example of path aliases in the webpack config for #467

Next need to do the TypeScript example