### PR TITLE
Next.js: Verify that non-page components are incorrectly treated as pages

### DIFF
--- a/examples/nextjs/components/UsingHelper.jsx
+++ b/examples/nextjs/components/UsingHelper.jsx
@@ -1,0 +1,9 @@
+import * as React from 'react'
+
+import { hello } from './helpers';
+
+export function UsingHelper() {
+  return (
+    <>{hello()}</>
+  )
+}

--- a/examples/nextjs/components/helpers/hello-world.js
+++ b/examples/nextjs/components/helpers/hello-world.js
@@ -1,0 +1,1 @@
+export const hello = () => 'Hello World!'

--- a/examples/nextjs/components/helpers/index.js
+++ b/examples/nextjs/components/helpers/index.js
@@ -1,0 +1,1 @@
+export * from './hello-world'

--- a/examples/nextjs/cypress/components/UsingHelper.spec.jsx
+++ b/examples/nextjs/cypress/components/UsingHelper.spec.jsx
@@ -1,0 +1,12 @@
+/// <reference types="cypress" />
+import * as React from 'react'
+import { mount } from 'cypress-react-unit-test'
+import { UsingHelper } from '../../components/UsingHelper'
+
+describe('Component using helper with * export', () => {
+  it('Renders component', () => {
+    mount(<UsingHelper />)
+
+    cy.contains('Hello World!')
+  })
+})

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -7,7 +7,7 @@
     "dev": "next",
     "build": "next build",
     "start": "next start",
-    "test": "cypress-expect run --min-passing 10",
+    "test": "cypress-expect run --min-passing 11",
     "cy:open": "cypress open",
     "build:static": "next build && next out",
     "check-coverage": "check-coverage components/Search.jsx pages/index.js pages/router.js",


### PR DESCRIPTION
Currently, all code within `config.projectRoot` are treated as Next.js pages, ref. https://github.com/bahmutov/cypress-react-unit-test/blob/d65d2fb8b2e0f1e28c76e8697929270247959b09/plugins/next/file-preprocessor.js#L23

Since Next.js adds some additional checks to Next.js pages that enforces certain limits, these limits will apply to the entire `config.projectRoot`. One of these limits is that a page cannot contain `export * from '...'`. This test verifies that a component outside of the `/pages` directory cannot use any code that contains a `export *` statement.

Changing the referenced line to ```pagesDir: `${config.componentFolder}/pages`,``` fixes the problem for me, but I realize that it might not work for everyone depending on what their value of `componentFolder` in `cypress.json` is and how that relates to their application code. In my case, I have `"componentFolder": "src",` and all my component tests are located together with the code they are testing inside of `src`.

<!-- if this PR closes an issue note the number below -->

- Adds test case to verify that #513 is a problem
