### PR TITLE
chore(docs): update example rollup link in recipe docs

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -157,4 +157,4 @@ commonjs(),
 replace({ 'process.env.NODE_ENV': JSON.stringify('development') }),
 ```
 
-See [examples/rollup](examples/rollup) folder for full example.
+See [examples/rollup](../examples/rollup) folder for full example.


### PR DESCRIPTION
Updates the relative path for the `examples/rollup` link in the `docs/recipes.md` so that it points to the correct location.

PRs closed:
- N/A

Tasks to be done:
- [ ] pull request was reviewed and approved
- [ ] can be merged if all tasks have been checked
- [ ] anything else to do before merging
