### PR TITLE
feat(react-scripts): allow modifying the final preprocessorOptions

### DIFF
--- a/plugins/cra-v3/file-preprocessor.js
+++ b/plugins/cra-v3/file-preprocessor.js
@@ -26,7 +26,7 @@ const getWebpackPreprocessorOptions = opts => {
   return options
 }
 
-module.exports = config => {
+module.exports = (config, options = {}) => {
   debug('env object %o', config.env)
 
   const coverageIsDisabled =
@@ -60,7 +60,15 @@ module.exports = config => {
     // insert Babel plugin to mock named imports
     looseModules: true,
   }
-  const preprocessorOptions = getWebpackPreprocessorOptions(opts)
+  let preprocessorOptions = getWebpackPreprocessorOptions(opts)
+
+  if (
+    options.preprocessorOptionsFinal &&
+    typeof options.preprocessorOptionsFinal === 'function'
+  ) {
+    debug('preprocessorOptionsFinal callback found and calling it')
+    preprocessorOptions = options.preprocessorOptionsFinal(preprocessorOptions)
+  }
 
   debug('final webpack options %o', preprocessorOptions.webpackOptions)
 

--- a/plugins/react-scripts/index.js
+++ b/plugins/react-scripts/index.js
@@ -1,8 +1,8 @@
 const filePreprocessor = require('../cra-v3/file-preprocessor')
 
-module.exports = (on, config) => {
+module.exports = (on, config, options) => {
   require('@cypress/code-coverage/task')(on, config)
-  on('file:preprocessor', filePreprocessor(config))
+  on('file:preprocessor', filePreprocessor(config, options))
   // IMPORTANT to return the config object
   // with the any changed environment variables
   return config


### PR DESCRIPTION
Inspired by Storybook's [webpackFinal](https://storybook.js.org/docs/react/configure/webpack) option, this allows passing a third parameter to the react-scripts function. If `preprocessorOptionsFinal` as function is given, it'll get called with the final `preprocessorOptions` to give user space a chance to modify things, like adjusting the webpack config, e.g.

```js
    reactScripts(on, config, {
        preprocessorOptionsFinal(preprocessorOptions) {
            preprocessorOptions.webpackOptions.devtool = false
            return preprocessorOptions
        },
    })
```

I suppose this would need some tests and/or documentation, just wanted to check if this might be a proper way to approach it

<!-- if this PR closes an issue note the number below -->

- Attempt to fix #551 

<!-- please list any tasks to be done before merging -->

- [ ] pull request was reviewed and approved
- [ ] can be merged if all tasks have been checked
- [ ] anything else to do before merging
